### PR TITLE
fix: do not show Debian watermark

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+plymouth (0.9.5.1-deepin3) unstable; urgency=medium
+
+  * Do not show Debian watermark.
+  * Debian's Plymouth hook installs a Debian watermark on the right side of
+    the display if:
+    * The user has installed desktop-base (a very common practice for Debian
+      desktop systems, but not for deepin/UOS, as we do not use tasksel).
+    * The user has chosen a two-step-type Plymouth theme (which deepin-logo is
+      one of that type).
+
+ -- Mingcong Bai <baimingcong@uniontech.com>  Mon, 29 Jul 2024 14:44:07 +0800
+
 plymouth (0.9.5.1-deepin2) unstable; urgency=medium
 
   * fix: systemd files move to /usr, from patch

--- a/debian/local/plymouth.hook
+++ b/debian/local/plymouth.hook
@@ -127,18 +127,6 @@ case "${THEME_NAME}" in
 			mkdir -p "${DESTDIR}/etc/default"
 			cp /etc/default/keyboard "${DESTDIR}/etc/default"
 		fi
-
-		# for two-step
-		case "$(sed -n 's/^ModuleName=\(.*\)/\1/p' ${THEME})" in
-			two-step)
-				# add watermark.png
-				logo=/usr/share/desktop-base/debian-logos/logo-text-version-64.png
-				if [ -e $logo ]
-				then
-					cp $logo "${DESTDIR}/${IMAGE_DIR}/watermark.png"
-				fi
-				;;
-		esac
 		;;
 esac
 


### PR DESCRIPTION
Debian's Plymouth hook installs a Debian watermark on the right side of the display if:

* The user has installed desktop-base (a very common practice for Debian desktop systems, but not for deepin/UOS, as we do not use tasksel).
* The user has chosen a two-step-type Plymouth theme (which deepin-logo is one of that type).