### PR TITLE
fix: Logo not centered when multiple monitors are used

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+plymouth (24.004.60-2deepin5) unstable; urgency=medium
+
+  * fix: Logo not centered when multiple monitors are used.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Fri, 12 Dec 2025 14:57:15 +0800
+
 plymouth (24.004.60-2deepin4) unstable; urgency=medium
 
   * fix: cann't display logo when boot.

--- a/debian/patches/0001-Fix-script-Ensure-Window.GetX-Y-returns-0-for-correc.patch
+++ b/debian/patches/0001-Fix-script-Ensure-Window.GetX-Y-returns-0-for-correc.patch
@@ -1,0 +1,61 @@
+From 8d3827fc99175fe67e70c31940301495596f21a0 Mon Sep 17 00:00:00 2001
+From: xinpeng wang <wangxinpeng@uniontech.com>
+Date: Mon, 1 Dec 2025 16:16:19 +0800
+Subject: [PATCH] Fix: script: Ensure Window.GetX/Y() returns 0 for correct
+ multi-display centering
+
+When multiple displays of different resolutions are attached, the Plymouth script
+plugin uses a virtual "max canvas" (defined by max_width and max_height) for
+rendering. Individual displays calculate their offsets (display->x, display->y)
+relative to this max canvas for mirroring/centering.
+
+The script-level centering formula, as seen in example themes:
+logo.sprite.SetX (Window.GetX() + Window.GetWidth() / 2 - logo.image.GetWidth() / 2);
+
+Issue:
+For the script to correctly calculate the absolute center position on the max canvas,
+Window.GetX() must conceptually return the origin of the max canvas, which is 0.
+
+However, the non-indexed implementation of sprite_window_get_x (and GetY) currently
+returns the maximum calculated display offset (MAX(display->x)), which corresponds to
+the offset of the smallest display. This incorrect, non-zero return value introduces
+an unintended shift, pushing sprites (like the logo) off-center, and breaking the
+centering logic.
+
+Solution:
+Update sprite_window_get_x and sprite_window_get_y to return the minimum calculated
+display offset (MIN(display->x)). Since the largest display always has an offset of 0,
+this guarantees that Window.GetX() and Window.GetY() return 0 when called without
+parameters, correctly anchoring the script-calculated center position to the absolute
+max canvas origin.
+
+Signed-off-by: xinpeng.wang <wangxinpeng@uniontech.com>
+---
+ src/plugins/splash/script/script-lib-sprite.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/plugins/splash/script/script-lib-sprite.c b/src/plugins/splash/script/script-lib-sprite.c
+index 2c97f4a9..a269ee13 100644
+--- a/src/plugins/splash/script/script-lib-sprite.c
++++ b/src/plugins/splash/script/script-lib-sprite.c
+@@ -284,7 +284,7 @@ static script_return_t sprite_window_get_x (script_state_t *state,
+              node;
+              node = ply_list_get_next_node (data->displays, node)) {
+                 display = ply_list_node_get_data (node);
+-                x = MAX (x, display->x);
++                x = MIN (x, display->x);
+         }
+         return script_return_obj (script_obj_new_number (x));
+ }
+@@ -319,7 +319,7 @@ static script_return_t sprite_window_get_y (script_state_t *state,
+              node;
+              node = ply_list_get_next_node (data->displays, node)) {
+                 display = ply_list_node_get_data (node);
+-                y = MAX (y, display->y);
++                y = MIN (y, display->y);
+         }
+         return script_return_obj (script_obj_new_number (y));
+ }
+-- 
+2.20.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -9,3 +9,4 @@ ply-boot-splash-Set-unbuffered-input-when-creating-a.patch
 fix-default-plymouth-theme.patch
 reset-msg-positon-on-two-step.patch
 uniontech-retry-when-open-drm-failed.patch
+0001-Fix-script-Ensure-Window.GetX-Y-returns-0-for-correc.patch


### PR DESCRIPTION
Log: 解决连接多显示器时logo不居中的问题
Bug: 311059